### PR TITLE
Add metadata.txt

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -1,0 +1,37 @@
+# This file contains metadata for your plugin. Beginning
+# with version 1.8 this is the preferred way to supply information about a
+# plugin. The current method of embedding metadata in __init__.py will
+# be supported until version 2.0
+
+# This file should be included when you package your plugin.
+
+# Mandatory items:
+
+
+[general]
+name=Fast SQL layer
+qgisMinimumVersion=1.7
+description=Dockable SQL editor with code highlighting that adds query layers
+version=0.2.4
+author=Pablo Carreira
+email=pablotcarreira@gmail.com
+
+# end of mandatory metadata
+
+# Optional items:
+
+# Uncomment the following line and add your changelog entries:
+# changelog=
+
+# tags are comma separated with spaces allowed
+tags=vector,postgis,PostGIS-layer,SQL
+
+homepage=https://github.com/pablotcarreira/Fast-SQL-Layer
+tracker=https://github.com/pablotcarreira/Fast-SQL-Layer/issues
+repository=https://github.com/pablotcarreira/Fast-SQL-Layer
+icon=icon.png
+# experimental flag
+experimental=False
+
+# deprecated flag (applies to the whole plugin, not just a single version
+deprecated=False


### PR DESCRIPTION
The plugin does not load in recent versions of QGIS master due to lack of a metadata.txt file.
